### PR TITLE
Multitargetingfor netstandard

### DIFF
--- a/MSBLOC.Core.Tests/MSBLOC.Core.Tests.csproj
+++ b/MSBLOC.Core.Tests/MSBLOC.Core.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net471</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/MSBLOC.Core.Tests/Services/ParserTests.cs
+++ b/MSBLOC.Core.Tests/Services/ParserTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
@@ -24,8 +25,9 @@ namespace MSBLOC.Core.Tests.Services
 
         private static string GetResourcePath(string file)
         {
-            var location = typeof(ParserTests).GetTypeInfo().Assembly.Location;
-            var dirPath = Path.GetDirectoryName(location);
+            var codeBaseUrl = new Uri(Assembly.GetExecutingAssembly().CodeBase);
+            var codeBasePath = Uri.UnescapeDataString(codeBaseUrl.AbsolutePath);
+            var dirPath = Path.GetDirectoryName(codeBasePath);
             dirPath.ShouldNotBeNull();
             return Path.Combine(dirPath, "Resources", file);
         }


### PR DESCRIPTION
MSBLOC.Core.Tests will now target .NETCore and .NETFramework.