### PR TITLE
Having calls to IGitHubUserModelService cached per request.

### DIFF
--- a/MSBLOC.Core.Tests/MSBLOC.Core.Tests.csproj
+++ b/MSBLOC.Core.Tests/MSBLOC.Core.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Bogus" Version="22.3.2" />
     <PackageReference Include="FluentAssertions" Version="5.4.1" />
     <PackageReference Include="GitHubJwt" Version="0.0.2" />
     <PackageReference Include="jose-jwt" Version="2.4.0" />
@@ -20,12 +21,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\MSBLOC.Core\MSBLOC.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="Bogus">
-      <HintPath>..\..\..\.nuget\packages\bogus\22.3.1\lib\netstandard2.0\Bogus.dll</HintPath>
-    </Reference>
   </ItemGroup>
 
   <ItemGroup>

--- a/MSBLOC.Web/MSBLOC.Web.csproj
+++ b/MSBLOC.Web/MSBLOC.Web.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="2.0.0" />
     <PackageReference Include="BuildBundlerMinifier" Version="2.8.391" />
+    <PackageReference Include="Castle.Core" Version="4.3.1" />
     <PackageReference Include="GitHubJwt" Version="0.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.1.1" />

--- a/MSBLOC.Web/Startup.cs
+++ b/MSBLOC.Web/Startup.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Castle.DynamicProxy;
 using GitHubJwt;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
@@ -101,6 +102,7 @@ namespace MSBLOC.Web
                 var gitHubClient = await s.GetService<IGitHubAppClientFactory>().CreateClient(tokenGenerator, repoOwner);
                 return new CheckRunSubmitter(gitHubClient.Check.Run, s.GetService<ILogger<CheckRunSubmitter>>());
             });
+            services.AddSingleton<IProxyGenerator, ProxyGenerator>();
             
             services.AddScoped<ITempFileService, LocalTempFileService>();
             services.AddScoped<IBinaryLogProcessor, BinaryLogProcessor>();
@@ -113,7 +115,14 @@ namespace MSBLOC.Web
             services.AddScoped<IGitHubClientFactory, GitHubClientFactory>();
             services.AddScoped<IGitHubAppClientFactory, GitHubAppClientFactory>();
             services.AddScoped<IGitHubUserClientFactory, GitHubUserClientFactory>();
-            services.AddScoped<IGitHubUserModelService, GitHubUserModelService>();
+            services.AddScoped<GitHubUserModelService>();
+            services.AddScoped<IGitHubUserModelService>(s =>
+            {
+                var proxyGenerator = s.GetService<IProxyGenerator>();
+                var target = s.GetService<GitHubUserModelService>();
+                var interceptor = new InMemoryCachingInterceptor();
+                return proxyGenerator.CreateInterfaceProxyWithTarget<IGitHubUserModelService>(target, interceptor);
+            });
             services.AddScoped<IAccessTokenService, AccessTokenService>();
 
             services.AddTransient<IMSBLOCService, MSBLOCService>();

--- a/MSBLOC.Web/Util/InMemoryCachingInterceptor.cs
+++ b/MSBLOC.Web/Util/InMemoryCachingInterceptor.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Castle.DynamicProxy;
+
+namespace MSBLOC.Web.Util
+{
+    public class InMemoryCachingInterceptor : IInterceptor
+    {
+        private readonly Dictionary<string, object> _cache = new Dictionary<string, object>();
+
+        public void Intercept(IInvocation invocation)
+        {
+            var cacheKey = GenerateCacheKey(invocation.Method.Name, invocation.Arguments);
+
+            if (!_cache.ContainsKey(cacheKey))
+            {
+                lock (_cache)
+                {
+                    if (!_cache.ContainsKey(cacheKey))
+                    {
+                        invocation.Proceed();
+                        _cache[cacheKey] = invocation.ReturnValue;
+                    }
+                }
+            }
+
+            invocation.ReturnValue = _cache[cacheKey];
+        }
+
+        private static string GenerateCacheKey(string methodName, IReadOnlyCollection<object> arguments)
+        {
+            if (arguments == null || arguments.Count == 0) return methodName;
+
+            return $"{methodName}::{string.Join("::", arguments.Select(arg => arg.ToString()))}";
+        }
+    }
+}


### PR DESCRIPTION
Adding `InMemoryCachingInterceptor` that will allow us to cache calls to third parties for the current request.